### PR TITLE
fix bzlead compat when space age is not enabled

### DIFF
--- a/info.json
+++ b/info.json
@@ -3,7 +3,7 @@
   "title": "Crushing Industry",
   "description": "Add early-game crusher variants for crushing sand to smelt into glass, and crushing ore and coal for more efficient smelting",
   "author": "SafTheLamb",
-  "version": "0.3.15",
+  "version": "0.3.14",
   "factorio_version": "2.0",
   "homepage": "https://github.com/SafTheLamb/fm-crushing-industry",
   "package": {

--- a/info.json
+++ b/info.json
@@ -3,7 +3,7 @@
   "title": "Crushing Industry",
   "description": "Add early-game crusher variants for crushing sand to smelt into glass, and crushing ore and coal for more efficient smelting",
   "author": "SafTheLamb",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "factorio_version": "2.0",
   "homepage": "https://github.com/SafTheLamb/fm-crushing-industry",
   "package": {

--- a/prototypes/compat/bz-ores-updates.lua
+++ b/prototypes/compat/bz-ores-updates.lua
@@ -6,7 +6,7 @@ if data.raw.furnace["basic-crusher"] then
   data.raw.furnace["basic-crusher"].hidden = true
 end
 
-if mods["bzlead"] then
+if mods["bzlead"] and mods["space-age"] then
   data.raw.recipe["alternative-metallic-asteroid-crushing"].hidden = true
   if settings.startup["crushing-industry-byproducts"].value then
     frep.remove_result("metallic-asteroid-crushing", "stone")


### PR DESCRIPTION
Found this while trying to update compat for bzlead and krastorio2 2.0 since k2 doesn't allow space age.